### PR TITLE
Add methods for webserver-based workflow

### DIFF
--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -466,7 +466,7 @@ class MemberAPI(PublicAPI):
         :yields: string
             The URL ready to be offered as a link to the user.
         """
-        if not isinstance(scope, basestring):
+        if isinstance(scope, (list, tuple)):
             scope = " ".join(scope)
         data = {"client_id": self._key, "scope": scope,
                 "response_type": "code", "redirect_uri": redirect_uri}

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -461,9 +461,9 @@ class MemberAPI(PublicAPI):
             Determines whether the log-in or registration form will be shown by
             default.
 
-        Yields
+        Returns
         -------
-        :yields: string
+        :returns: string
             The URL ready to be offered as a link to the user.
         """
         if isinstance(scope, (list, tuple)):

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -433,9 +433,9 @@ class MemberAPI(PublicAPI):
         self._update_activities(orcid_id, token, requests.put, request_type,
                                 data, put_code)
 
-    def compose_orcid_url(self, scope, redirect_uri, state=None,
-                          family_names=None, given_names=None, email=None,
-                          lang=None, show_login=None):
+    def get_login_url(self, scope, redirect_uri, state=None,
+                      family_names=None, given_names=None, email=None,
+                      lang=None, show_login=None):
         """Return a URL for a user to login/register with ORCID.
 
         Parameters

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -1,5 +1,8 @@
 """Implementation of python-orcid library."""
 
+import simplejson as json
+import requests
+
 import sys
 if sys.version_info[0] == 2:
     from urllib import urlencode
@@ -7,9 +10,6 @@ if sys.version_info[0] == 2:
 else:
     from urllib.parse import urlencode
     string_types = str,
-
-import simplejson as json
-import requests
 
 SEARCH_VERSION = "/v1.2"
 VERSION = "/v2.0_rc1"

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -1,10 +1,13 @@
 """Implementation of python-orcid library."""
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    # Python 2
+import sys
+if sys.version_info[0] == 2:
     from urllib import urlencode
+    string_types = basestring,
+else:
+    from urllib.parse import urlencode
+    string_types = str,
+
 import simplejson as json
 import requests
 
@@ -439,7 +442,7 @@ class MemberAPI(PublicAPI):
 
         Parameters
         ----------
-        :param scope: string or list of strings
+        :param scope: string or iterable of strings
             The scope(s) of the authorization request.
         :param redirect_uri: string
             The URI to which the user's browser should be redirected after the
@@ -465,7 +468,7 @@ class MemberAPI(PublicAPI):
         :returns: string
             The URL ready to be offered as a link to the user.
         """
-        if isinstance(scope, (list, tuple)):
+        if not isinstance(scope, string_types):
             scope = " ".join(scope)
         data = {"client_id": self._key, "scope": scope,
                 "response_type": "code", "redirect_uri": redirect_uri}

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -261,7 +261,7 @@ class MemberAPI(PublicAPI):
 
         return response['access_token']
 
-    def get_token_by_code(self, authorization_code, redirect_uri):
+    def get_token_from_authorization_code(self, authorization_code, redirect_uri):
         """Like `get_token`, but using an OAuth 2 authorization code.
 
         Use this method if you run a webserver that serves as an endpoint for
@@ -518,7 +518,8 @@ class MemberAPI(PublicAPI):
 
         uri = json.loads(response.text)['redirectUri']['value']
         authorization_code = uri[uri.rfind('=') + 1:]
-        return self.get_token_by_code(redirect_uri, authorization_code)
+        return self.get_token_from_authorization_code(redirect_uri,
+                                                      authorization_code)
 
     def _get_access_token_from_orcid(self, scope):
         payload = {'client_id': self._key,

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -469,21 +469,21 @@ class MemberAPI(PublicAPI):
             The URL ready to be offered as a link to the user.
         """
         if not isinstance(scope, string_types):
-            scope = " ".join(scope)
-        data = {"client_id": self._key, "scope": scope,
-                "response_type": "code", "redirect_uri": redirect_uri}
+            scope = " ".join(sorted(set(scope)))
+        data = [("client_id", self._key), ("scope", scope),
+                ("response_type", "code"), ("redirect_uri", redirect_uri)]
         if state:
-            data["state"] = state
+            data.append(("state", state))
         if family_names:
-            data["family_names"] = family_names
+            data.append(("family_names", family_names))
         if given_names:
-            data["given_names"] = given_names
+            data.append(("given_names", given_names))
         if email:
-            data["email"] = email
+            data.append(("email", email))
         if lang:
-            data["lang"] = lang
+            data.append(("lang", lang))
         if show_login is not None:
-            data["show_login"] = "true" if show_login else "false"
+            data.append(("show_login", "true" if show_login else "false"))
         return self._login_or_register_endpoint + "?" + urlencode(data)
 
     def _authenticate(self, user_id, password, redirect_uri, session, scope):

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -15,7 +15,6 @@ __version__ = "0.5.1"
 
 
 class PublicAPI(object):
-
     """Public API."""
 
     def __init__(self, sandbox=False):
@@ -159,7 +158,6 @@ class PublicAPI(object):
 
 
 class MemberAPI(PublicAPI):
-
     """Member API."""
 
     def __init__(self, institution_key, institution_secret, sandbox=False):
@@ -261,7 +259,8 @@ class MemberAPI(PublicAPI):
 
         return response['access_token']
 
-    def get_token_from_authorization_code(self, authorization_code, redirect_uri):
+    def get_token_from_authorization_code(self, authorization_code,
+                                          redirect_uri):
         """Like `get_token`, but using an OAuth 2 authorization code.
 
         Use this method if you run a webserver that serves as an endpoint for

--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -178,14 +178,16 @@ class MemberAPI(PublicAPI):
             self._auth_url = 'https://sandbox.orcid.org/signin/auth.json'
             self._authorize_url = \
                 'https://sandbox.orcid.org/oauth/custom/authorize.json'
-            self._login_or_register_endpoint = "https://sandbox.orcid.org/oauth/authorize"
+            self._login_or_register_endpoint = \
+                "https://sandbox.orcid.org/oauth/authorize"
             self._token_url = "https://api.sandbox.orcid.org/oauth/token"
         else:
             self._endpoint_member = "https://api.orcid.org"
             self._auth_url = 'https://orcid.org/signin/auth.json'
             self._authorize_url = \
                 'https://orcid.org/oauth/custom/authorize.json'
-            self._login_or_register_endpoint = "https://orcid.org/oauth/authorize"
+            self._login_or_register_endpoint = \
+                "https://orcid.org/oauth/authorize"
             self._token_url = "https://api.orcid.org/oauth/token"
         PublicAPI.__init__(self, sandbox)
 
@@ -260,10 +262,11 @@ class MemberAPI(PublicAPI):
         return response['access_token']
 
     def get_token_by_code(self, authorization_code, redirect_uri):
-        """Like `get_token`, but using an OAuth 2 authorization code.  Use this
-        method if you run a webserver that serves as an endpoint for the
-        redirect URI. The webserver can retrieve the authorization code from
-        the URL that is requested by ORCID.
+        """Like `get_token`, but using an OAuth 2 authorization code.
+
+        Use this method if you run a webserver that serves as an endpoint for
+        the redirect URI. The webserver can retrieve the authorization code
+        from the URL that is requested by ORCID.
 
         Parameters
         ----------
@@ -465,7 +468,8 @@ class MemberAPI(PublicAPI):
         """
         if not isinstance(scope, basestring):
             scope = " ".join(scope)
-        data = {"client_id": self._key, "scope": scope, "response_type": "code", "redirect_uri": redirect_uri}
+        data = {"client_id": self._key, "scope": scope,
+                "response_type": "code", "redirect_uri": redirect_uri}
         if state:
             data["state"] = state
         if family_names:

--- a/orcid/testsuite/test_orcid.py
+++ b/orcid/testsuite/test_orcid.py
@@ -314,3 +314,31 @@ def test_get_token(memberAPI, authorization_code, token_json):
     # The token doesn't change on the sandbox
     assert token == "token"
     httpretty.disable_()
+
+
+def test_get_login_url(memberAPI):
+    """Test constructing a login/registration URL."""
+    redirect_uri = "https://www.inspirehep.net"
+    expected_url = "https://sandbox.orcid.org/oauth/authorize?client_id=id&" \
+        "scope=%2Forcid-profile%2Fread-limited&response_type=code&" \
+        "redirect_uri=https%3A%2F%2Fwww.inspirehep.net"
+    assert memberAPI.get_login_url("/orcid-profile/read-limited",
+                                   redirect_uri) == expected_url
+    assert memberAPI.get_login_url(["/orcid-profile/read-limited"],
+                                   redirect_uri) == expected_url
+    assert memberAPI.get_login_url(2 * ["/orcid-profile/read-limited"],
+                                   redirect_uri) == expected_url
+    kwargs = {"state": "F0OCMU37MV3GMUX1",
+              "family_names": "Carberry", "given_names": "Josiah Stinkney",
+              "email": "j.s.carberry@example.com",
+              "lang": "en", "show_login": True}
+    assert memberAPI.get_login_url(
+        ["/orcid-profile/read-limited", "/affiliations/create",
+         "/orcid-works/create"], redirect_uri, **kwargs) == \
+        "https://sandbox.orcid.org/oauth/authorize?client_id=id&" \
+        "scope=%2Faffiliations%2Fcreate+%2Forcid-profile%2Fread-limited+" \
+        "%2Forcid-works%2Fcreate&response_type=code&" \
+        "redirect_uri=https%3A%2F%2Fwww.inspirehep.net&" \
+        "state=F0OCMU37MV3GMUX1&family_names=Carberry&" \
+        "given_names=Josiah+Stinkney&email=j.s.carberry%40example.com&" \
+        "lang=en&show_login=true"


### PR DESCRIPTION
We need the following workflow:
1. We offer a user a link to ORCID.  The user follows this link.
2. The user logs into ORCID or registers with it.
3. ORCID redirects to the redirect URI, which is our webserver.
4. This webserver fetches an OAuth 2 access token.

For this workflow, I added two methods to `MemberAPI`.

Note that this is also possible for non-members.  However, you need an app key and secret, and this is only set in the `MemberAPI` class.  I don't know whether this is as intended or whether you plan to give the `PublicAPI` optional `_key` and `_secret` fields.
