### PR TITLE
Remove old parameter from method docstrings

### DIFF
--- a/orcid/orcid.py
+++ b/orcid/orcid.py
@@ -168,9 +168,6 @@ class PublicAPI(object):
             Query in line with the chosen method.
         :param method: string
             One of 'lucene', 'edismax', 'dismax'
-        :param search_field: string
-            Scope used for seaching. The default one allows to search
-            everywhere.
         :param pagination: integer
             How many papers should be fetched with the request.
         :param access_token: string
@@ -583,9 +580,6 @@ class MemberAPI(PublicAPI):
             Index of the first record requested. Use for pagination.
         :param rows: string
             Number of records requested. Use for pagination.
-        :search_field: string
-            Scope used for seaching. The default one allows to search
-            everywhere.
         :param access_token: string
             If obtained before, the access token to use to pass through
             authorization. Note that if this argument is not provided,
@@ -620,9 +614,6 @@ class MemberAPI(PublicAPI):
             Query in line with the chosen method.
         :param method: string
             One of 'lucene', 'edismax', 'dismax'
-        :param search_field: string
-            Scope used for seaching. The default one allows to search
-            everywhere.
         :param pagination: integer
             How many papers should be fetched with the request.
         :param access_token: string


### PR DESCRIPTION
The parameter `search_field` was removed from the code for 2.0 but left in the docstrings