### PR TITLE
Save the actual http response in an instance attribute

### DIFF
--- a/orcid/testsuite/test_orcid.py
+++ b/orcid/testsuite/test_orcid.py
@@ -9,6 +9,7 @@ from orcid import MemberAPI
 from orcid import PublicAPI
 from time import sleep
 from requests.exceptions import Timeout
+from requests.models import Response
 
 from .helpers import exemplary_work, exemplary_work_xml
 from .helpers import WORK_NAME2, WORK_NAME3
@@ -150,6 +151,15 @@ def test_search_public_generator_pagination(publicAPI):
     # Just check if the request suceeded
 
     assert 'orcid-identifier' in result
+
+
+def test_publicapi_http_response(publicAPI):
+    publicAPI.get_token(USER_EMAIL,
+                        USER_PASSWORD,
+                        REDIRECT_URL,
+                        '/read-limited')
+    assert isinstance(publicAPI.response, Response)
+    assert publicAPI.response.status_code == 200
 
 
 @pytest.fixture
@@ -328,6 +338,14 @@ def test_get_token(memberAPI):
                                 REDIRECT_URL)
 
     assert fullmatch(TOKEN_RE, token) is not None
+
+
+def test_memberapi_http_response(memberAPI):
+    memberAPI.get_token(USER_EMAIL,
+                        USER_PASSWORD,
+                        REDIRECT_URL)
+    assert isinstance(memberAPI.response, Response)
+    assert memberAPI.response.status_code == 200
 
 
 def test_timeout():

--- a/orcid/testsuite/test_orcid.py
+++ b/orcid/testsuite/test_orcid.py
@@ -157,9 +157,10 @@ def test_publicapi_http_response(publicAPI):
     publicAPI.get_token(USER_EMAIL,
                         USER_PASSWORD,
                         REDIRECT_URL,
-                        '/read-limited')
-    assert isinstance(publicAPI.response, Response)
-    assert publicAPI.response.status_code == 200
+                        '/read-limited',
+                        do_store_raw_response=True)
+    assert isinstance(publicAPI.raw_response, Response)
+    assert publicAPI.raw_response.status_code == 200
 
 
 @pytest.fixture
@@ -343,9 +344,10 @@ def test_get_token(memberAPI):
 def test_memberapi_http_response(memberAPI):
     memberAPI.get_token(USER_EMAIL,
                         USER_PASSWORD,
-                        REDIRECT_URL)
-    assert isinstance(memberAPI.response, Response)
-    assert memberAPI.response.status_code == 200
+                        REDIRECT_URL,
+                        do_store_raw_response=True)
+    assert isinstance(memberAPI.raw_response, Response)
+    assert memberAPI.raw_response.status_code == 200
 
 
 def test_timeout():


### PR DESCRIPTION
We have some use cases in our team (Inspire at CERN) where we need some introspection on the actual response (the response coming from the Python HTTP `requests` library).
Introspections about HTTP status codes, request and response content and headers